### PR TITLE
Better readability for token exceptions

### DIFF
--- a/dippy/core/validators.py
+++ b/dippy/core/validators.py
@@ -14,10 +14,10 @@ def token_validator(instance: Any, field: Attribute, value: Any):
     )
     if not isinstance(value, str):
         raise MalformedDiscordToken(
-            f"The Discord token must be a string. {instructions}"
+            f"The Discord Token provided must be a string. {instructions}"
         )
 
     if not discord_token_pattern.match(value.strip()):
         raise MalformedDiscordToken(
-            f"The Discord token didn't look to be valid. {instructions}"
+            f"The Discord Token provided isn\'t valid. {instructions}"
         )


### PR DESCRIPTION
There was a small "grammar typo" in [validators.py](https://github.com/ZechCodes/dippy.core/blob/v1-alpha/dippy/core/validators.py)

I also made the exception return a string that's more readable than the last one